### PR TITLE
Add Mac trackpad quit gesture example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# TrackpadQuit
+
+This repository contains a minimal example of a macOS application that quits the frontmost application when a four‑finger downward swipe is detected on the trackpad. It relies on the private `MultiTouchSupport.framework` used by macOS.
+
+## Building
+
+1. Open **Xcode** and create a new **macOS** project using the *App* template.
+2. Add the files in the `TrackpadQuit` directory to the project.
+3. Link against `MultiTouchSupport.framework`. This framework is located in `/System/Library/PrivateFrameworks`.
+4. Build and run the application. It runs as a background app with no dock icon.
+
+When four fingers swipe down on the trackpad, the app attempts to terminate the application that currently has focus.
+
+**Note:** because the app uses private APIs, future macOS versions may break this implementation, and it may not be suitable for App Store distribution.

--- a/TrackpadQuit/AppDelegate.swift
+++ b/TrackpadQuit/AppDelegate.swift
@@ -1,0 +1,23 @@
+import Cocoa
+
+class AppDelegate: NSObject, NSApplicationDelegate {
+    private var gestureMonitor: MultiTouchMonitor?
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        // run without dock icon
+        NSApp.setActivationPolicy(.accessory)
+        gestureMonitor = MultiTouchMonitor { [weak self] in
+            self?.quitFrontmostApplication()
+        }
+    }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        gestureMonitor = nil
+    }
+
+    private func quitFrontmostApplication() {
+        if let app = NSWorkspace.shared.frontmostApplication {
+            app.terminate()
+        }
+    }
+}

--- a/TrackpadQuit/MTSupport.swift
+++ b/TrackpadQuit/MTSupport.swift
@@ -1,0 +1,92 @@
+import Foundation
+import Cocoa
+
+// MARK: - MultiTouch private API bridging
+
+typealias MTDeviceRef = UnsafeMutableRawPointer
+
+typealias MTContactCallback = @convention(c) (
+    MTDeviceRef?,
+    UnsafeMutablePointer<MTContact>?,
+    Int32,
+    Double,
+    Int32,
+    UnsafeMutableRawPointer?
+) -> Void
+
+struct MTPoint {
+    var x: Float
+    var y: Float
+}
+
+struct MTContact {
+    var frame: Int32
+    var timestamp: Double
+    var identifier: Int32
+    var state: Int32
+    var normalized: MTPoint
+    var size: Float
+    var angle: Float
+    var majorAxis: Float
+    var minorAxis: Float
+}
+
+@_silgen_name("MTDeviceCreateList")
+func MTDeviceCreateList() -> Unmanaged<CFArray>?
+
+@_silgen_name("MTRegisterContactFrameCallback")
+func MTRegisterContactFrameCallback(_ device: MTDeviceRef, _ callback: MTContactCallback?, _ userInfo: UnsafeMutableRawPointer?)
+
+@_silgen_name("MTDeviceStart")
+func MTDeviceStart(_ device: MTDeviceRef, _ unknown: Int32)
+
+@_silgen_name("MTDeviceStop")
+func MTDeviceStop(_ device: MTDeviceRef)
+
+class MultiTouchMonitor {
+    private var devices: [MTDeviceRef] = []
+    private var callback: () -> Void
+
+    init(action: @escaping () -> Void) {
+        self.callback = action
+        start()
+    }
+
+    deinit {
+        stop()
+    }
+
+    private func start() {
+        guard let listRef = MTDeviceCreateList()?.takeRetainedValue() as? [MTDeviceRef] else { return }
+        devices = listRef
+        for device in devices {
+            let selfPtr = UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque())
+            MTRegisterContactFrameCallback(device, { device, contacts, count, timestamp, frame, refcon in
+                if let refcon = refcon {
+                    let monitor = Unmanaged<MultiTouchMonitor>.fromOpaque(refcon).takeUnretainedValue()
+                    monitor.handle(contacts: contacts, count: Int(count))
+                }
+            }, selfPtr)
+            MTDeviceStart(device, 0)
+        }
+    }
+
+    private func stop() {
+        for device in devices {
+            MTDeviceStop(device)
+        }
+        devices.removeAll()
+    }
+
+    private func handle(contacts: UnsafeMutablePointer<MTContact>?, count: Int) {
+        guard let contacts = contacts, count == 4 else { return }
+        let contactArray = Array(UnsafeBufferPointer(start: contacts, count: count))
+        // simple downward check using average y delta between contacts
+        let avgY = contactArray.map { $0.normalized.y }.reduce(0, +) / Float(count)
+        if avgY < -0.5 { // downward movement threshold
+            DispatchQueue.main.async {
+                self.callback()
+            }
+        }
+    }
+}

--- a/TrackpadQuit/main.swift
+++ b/TrackpadQuit/main.swift
@@ -1,0 +1,6 @@
+import Cocoa
+
+let app = NSApplication.shared
+let delegate = AppDelegate()
+app.delegate = delegate
+app.run()


### PR DESCRIPTION
## Summary
- create a minimal Swift example that quits the frontmost app when a four-finger downward swipe is detected
- provide MultiTouch private API helper
- document build instructions for the example

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6861f165644083218d1f47d0a90b5e7a